### PR TITLE
Use testtools so python 2.6 works correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 nose==1.3.0
 PyYAML==3.10
 flake8==2.2.3
+testtools

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -1,6 +1,6 @@
 import os
-from unittest import TestCase
 
+import testtools
 import yaml
 
 import restructuredtext_lint
@@ -15,7 +15,7 @@ An invalid rst file
 """
 
 
-class TestRestructuredtextLint(TestCase):
+class TestRestructuredtextLint(testtools.TestCase):
     def _load_file(self, filepath):
         """Load a file into memory"""
         f = open(filepath)


### PR DESCRIPTION
Certain functionality of the unittest code in python 2.6
does not exist and causes the tests to fail; the testtools
package provides a compat. layer that does work (by leveraging
the needed backports) so that the tests work correctly on python
2.6