### PR TITLE
#16 Feature: Possibility to pass many rst files at once

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 restructuredtext-lint changelog
 ===============================
+Unreleased - Added possibility to pass one or many .rst files to `rst-lint` command.
+
 0.11.3 - Documented added in new directives/roles
 
 0.11.2 - Added test failures for lint errors

--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,9 @@ For your convenience, we present a CLI utility ``rst-lint`` (also available as `
 .. code:: bash
 
     $ rst-lint --help
-    usage: rst-lint [-h] [--format FORMAT] [--encoding ENCODING] filepath
+    usage: rst-lint [-h] [--format FORMAT] [--encoding ENCODING] filepath [filepath ...]
 
-    Lint a reStructuredText file
+    Lint reStructuredText files
 
     positional arguments:
       filepath         File to lint


### PR DESCRIPTION
- Added possibility to pass one or many rst files to 'rst-lint' command.
- Moved tests out of the restructuredtext_lint (reduced build package size).