### PR TITLE
Expose version via -v or --version; Bump version to 0.14.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,17 +38,19 @@ For your convenience, we present a CLI utility ``rst-lint`` (also available as `
 .. code:: bash
 
     $ rst-lint --help
-    usage: rst-lint [-h] [--format FORMAT] [--encoding ENCODING] filepath [filepath ...]
+    usage: rst-lint [-h] [-v] [--format FORMAT] [--encoding ENCODING]
+                    filepath [filepath ...]
 
     Lint reStructuredText files
 
     positional arguments:
-      filepath         File to lint
+      filepath             File to lint
 
     optional arguments:
-      -h, --help            show this help message and exit
-      --format FORMAT       Format of output (e.g. text, json)
-      --encoding ENCODING   Encoding of the source file (e.g. utf-8)
+      -h, --help           show this help message and exit
+      -v, --version        show program's version number and exit
+      --format FORMAT      Format of the output (e.g. text, json)
+      --encoding ENCODING  Encoding of the input file (e.g. utf-8)
 
     $ rst-lint README.rst
     WARNING README.rst:2 Title underline too short.

--- a/restructuredtext_lint/__init__.py
+++ b/restructuredtext_lint/__init__.py
@@ -5,3 +5,5 @@ from restructuredtext_lint.lint import lint, lint_file
 # Export lint functions
 lint = lint
 lint_file = lint_file
+
+__version__ = '0.14.4'

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import sys
 
+from restructuredtext_lint import __version__
 from restructuredtext_lint.lint import lint_file
 
 
@@ -46,6 +47,8 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None):
 def main():
     # Set up options and parse arguments
     parser = argparse.ArgumentParser(description='Lint reStructuredText files')
+    parser.add_argument('-v', '--version', action='version',
+                        version='Lint reStructuredText v%s' % __version__)
     parser.add_argument('filepaths', metavar='filepath', nargs='+', type=str, help='File to lint')
     parser.add_argument('--format', default='text', type=str, help='Format of the output (e.g. text, json)')
     parser.add_argument('--encoding', type=str, help='Encoding of the input file (e.g. utf-8)')

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
 from setuptools import setup, find_packages
 
+# We define the version number in restructuredtext_lint/__init__.py
+# Here we can't use "import restructuredtext_lint" to access it
+# as "restructuredtext_lint.__version__" as that would tell us the
+# previously installed version (if any).
+__version__ = None
+for line in open('restructuredtext_lint/__init__.py'):
+    if (line.startswith('__version__ = ')):
+        exec(line.strip())
+if __version__ is None:
+    import sys
+    sys.exit("Internal error reading version number.")
 
 setup(
     name='restructuredtext_lint',
-    version='0.14.3',
+    version=__version__,
     description='reStructuredText linter',
     long_description=open('README.rst').read(),
     keywords=[


### PR DESCRIPTION
Pull request to implement #31.

Tested locally via ``python3.5 setup.py install`` and also confirmed ``python3.5 setup.py bdist`` seems to work.

Also checked:

```
$ pip3.5 uninstall restructuredtext_lint
$ python3.5 setup.py bdist_wheel
$ pip3.5 install dist/restructuredtext_lint-0.14.4-py3-none-any.whl
```

New behaviour:

```
$ rst-lint --version
Lint reStructuredText v0.14.4
$ rst-lint -v
Lint reStructuredText v0.14.4
```

NOTE: Might you want to reserve ``-v`` for a future verbose option?