### PR TITLE
Add zip_safe=False to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
     license='UNLICENSE',
     # DEV: Include files like `VERSION` in our package
     include_package_data=True,
+    # DEV: Mark our package as not zip safe so we can load `VERSION` on install
+    zip_safe=False,
     install_requires=open('requirements.txt').readlines(),
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -41,6 +43,5 @@ setup(
         'License :: Public Domain',
         'Operating System :: OS Independent',
         'Topic :: Text Processing :: Markup'
-    ],
-    zip_safe=False
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(
         'License :: Public Domain',
         'Operating System :: OS Independent',
         'Topic :: Text Processing :: Markup'
-    ]
+    ],
+    zip_safe=False
 )


### PR DESCRIPTION
setuptools will try and install a package from the zip file, but runs into some troubles if setup.py refers to `__file__`. I wasn't able to directly test that this fixed the following issue but it should.

```bash
$ python3 setup.py test
running test
Searching for restructuredtext-lint
Reading https://pypi.python.org/simple/restructuredtext-lint/
Best match: restructuredtext-lint 0.17.1
Downloading https://pypi.python.org/packages/73/d2/e2bfbf66319ba594dfedb72d2f3fd97917bda89446241e6c31b53742d72f/restructuredtext_lint-0.17.1.zip#md5=631584a1e930ceb83cc65fb1382ba9a6
Processing restructuredtext_lint-0.17.1.zip
Writing /tmp/easy_install-wy54kjij/restructuredtext_lint-0.17.1/setup.cfg
Running restructuredtext_lint-0.17.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-wy54kjij/restructuredtext_lint-0.17.1/egg-dist-tmp-xftmkcqw
zip_safe flag not set; analyzing archive contents...
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 243, in run_setup
    DirectorySandbox(setup_dir).run(runner)
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 273, in run
    return func()
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 242, in runner
    _execfile(setup_script, ns)
  File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 46, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-wy54kjij/restructuredtext_lint-0.17.1/setup.py", line 43, in <module>
  File "/usr/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 209, in run
    os.path.join(archive_root, 'EGG-INFO'), self.zip_safe()
  File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 245, in zip_safe
    return analyze_egg(self.bdist_dir, self.stubs)
  File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 355, in analyze_egg
    safe = scan_module(egg_dir, base, name, stubs) and safe
  File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 392, in scan_module
    code = marshal.load(f)
ValueError: bad marshal data (unknown type code)
```