### PR TITLE
Filter by error level threshold

### DIFF
--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -18,7 +18,8 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
 
     for filepath in filepaths:
         # Read and lint the file
-        file_errors = [error for error in lint_file(filepath, encoding=encoding) if error.level >= level]
+        unfiltered_file_errors = lint_file(filepath, encoding=encoding)
+        file_errors = [err for err in unfiltered_file_errors if err.level >= level]
 
         if not file_errors:
             if format == 'text':
@@ -26,18 +27,18 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
         else:
             error_occurred = True
             if format == 'text':
-                for error in file_errors:
+                for err in file_errors:
                     # e.g. WARNING readme.rst:12 Title underline too short.
-                    stream.write('{err.type} {err.source}:{err.line} {err.message}\n'.format(err=error))
+                    stream.write('{err.type} {err.source}:{err.line} {err.message}\n'.format(err=err))
             elif format == 'json':
                 error_dicts.extend({
-                    'line': error.line,
-                    'source': error.source,
-                    'level': error.level,
-                    'type': error.type,
-                    'message': error.message,
-                    'full_message': error.full_message,
-                } for error in file_errors)
+                    'line': err.line,
+                    'source': err.source,
+                    'level': err.level,
+                    'type': err.type,
+                    'message': err.message,
+                    'full_message': err.full_message,
+                } for err in file_errors)
 
     if format == 'json':
         stream.write(json.dumps(error_dicts))

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -27,7 +27,7 @@ with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as version_fi
     VERSION = version_file.read().strip()
 
 
-def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=2):
+def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=LEVEL_MAP.get('warning')):
     error_dicts = []
     error_occurred = False
 
@@ -74,7 +74,7 @@ def main():
     parser.add_argument('--encoding', type=str, help='Encoding of the input file (e.g. utf-8)')
     parser.add_argument('--level', default='warning', type=str, choices=LEVEL_MAP,
                         help='Minimum docutils linting error level to report and consider as failing '
-                        '(lower case string, default is warning)')
+                        '(lower case string, default is "warning")')
     args = parser.parse_args()
 
     # Want the level strings to appear in the --help text via choices, so convert now:

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -47,13 +47,13 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=LEVE
                     stream.write('{err.type} {err.source}:{err.line} {err.message}\n'.format(err=err))
             elif format == 'json':
                 error_dicts.extend({
-                    'line': err.line,
-                    'source': err.source,
-                    'level': err.level,
-                    'type': err.type,
-                    'message': err.message,
-                    'full_message': err.full_message,
-                } for err in file_errors)
+                    'line': error.line,
+                    'source': error.source,
+                    'level': error.level,
+                    'type': error.type,
+                    'message': error.message,
+                    'full_message': error.full_message,
+                } for error in file_errors)
 
     if format == 'json':
         stream.write(json.dumps(error_dicts))

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -12,7 +12,7 @@ with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as version_fi
     VERSION = version_file.read().strip()
 
 
-def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
+def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0, fail=0):
     error_dicts = []
     error_occurred = False
 
@@ -24,7 +24,9 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
             if format == 'text':
                 stream.write('INFO File {filepath} is clean.\n'.format(filepath=filepath))
         else:
-            error_occurred = True
+            for error in file_errors:
+                if error.level >= fail:
+                    error_occurred = True
             if format == 'text':
                 for error in file_errors:
                     if error.level >= level:
@@ -60,6 +62,9 @@ def main():
     parser.add_argument('--level', default=1, type=int, choices=(1, 2, 3, 4),
                         help='Minimum docutils linting error level to report '
                         '(integer, 1=info [default], 2=warning, 3=error, 4=severe)')
+    parser.add_argument('--fail', default=2, type=int, choices=(1, 2, 3, 4),
+                        help='Minimum docutils linting error level to consider as failing '
+                        '(integer, 1=info, 2=warning [default], 3=error, 4=severe)')
     args = parser.parse_args()
 
     # Run the main argument

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -44,14 +44,15 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
         stream.write(json.dumps(error_dicts))
 
     if error_occurred:
-        sys.exit(1)
+        sys.exit(2)  # Using 2 for linting failure, 1 for internal error
     else:
-        sys.exit(0)
+        sys.exit(0)  # Success!
 
 
 def main():
     # Set up options and parse arguments
-    parser = argparse.ArgumentParser(description='Lint reStructuredText files')
+    parser = argparse.ArgumentParser(description='Lint reStructuredText files. Returns 0 if all files pass linting, '
+                                     '1 for an internal error, and 2 if linting failed.')
     parser.add_argument('--version', action='version', version=VERSION)
     parser.add_argument('filepaths', metavar='filepath', nargs='+', type=str, help='File to lint')
     parser.add_argument('--format', default='text', type=str, help='Format of the output (e.g. text, json)')

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -12,26 +12,23 @@ with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as version_fi
     VERSION = version_file.read().strip()
 
 
-def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0, fail=0):
+def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
     error_dicts = []
     error_occurred = False
 
     for filepath in filepaths:
         # Read and lint the file
-        file_errors = lint_file(filepath, encoding=encoding)
+        file_errors = [error for error in lint_file(filepath, encoding=encoding) if error.level >= level]
 
         if not file_errors:
             if format == 'text':
                 stream.write('INFO File {filepath} is clean.\n'.format(filepath=filepath))
         else:
-            for error in file_errors:
-                if error.level >= fail:
-                    error_occurred = True
+            error_occurred = True
             if format == 'text':
                 for error in file_errors:
-                    if error.level >= level:
-                        # e.g. WARNING readme.rst:12 Title underline too short.
-                        stream.write('{err.type} {err.source}:{err.line} {err.message}\n'.format(err=error))
+                    # e.g. WARNING readme.rst:12 Title underline too short.
+                    stream.write('{err.type} {err.source}:{err.line} {err.message}\n'.format(err=error))
             elif format == 'json':
                 error_dicts.extend({
                     'line': error.line,
@@ -40,7 +37,7 @@ def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0, f
                     'type': error.type,
                     'message': error.message,
                     'full_message': error.full_message,
-                } for error in file_errors if error.level >= level)
+                } for error in file_errors)
 
     if format == 'json':
         stream.write(json.dumps(error_dicts))
@@ -59,11 +56,8 @@ def main():
     parser.add_argument('filepaths', metavar='filepath', nargs='+', type=str, help='File to lint')
     parser.add_argument('--format', default='text', type=str, help='Format of the output (e.g. text, json)')
     parser.add_argument('--encoding', type=str, help='Encoding of the input file (e.g. utf-8)')
-    parser.add_argument('--level', default=1, type=int, choices=(1, 2, 3, 4),
-                        help='Minimum docutils linting error level to report '
-                        '(integer, 1=info [default], 2=warning, 3=error, 4=severe)')
-    parser.add_argument('--fail', default=2, type=int, choices=(1, 2, 3, 4),
-                        help='Minimum docutils linting error level to consider as failing '
+    parser.add_argument('--level', default=2, type=int, choices=(1, 2, 3, 4),
+                        help='Minimum docutils linting error level to report and consider as failing '
                         '(integer, 1=info, 2=warning [default], 3=error, 4=severe)')
     args = parser.parse_args()
 

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -5,7 +5,22 @@ import json
 import os
 import sys
 
+from collections import OrderedDict
+
+from docutils.utils import Reporter
+
 from restructuredtext_lint.lint import lint_file
+
+# Generate our levels mapping for humans, using ordered dict for --help string
+# http://repo.or.cz/docutils.git/blob/422cede485668203abc01c76ca317578ff634b30:/docutils/docutils/utils/__init__.py#l65
+LEVEL_MAP = OrderedDict([
+    ('debug', Reporter.DEBUG_LEVEL),  # 0
+    ('info', Reporter.INFO_LEVEL),  # 1
+    ('warning', Reporter.WARNING_LEVEL),  # 2
+    ('error', Reporter.ERROR_LEVEL),  # 3
+    ('severe', Reporter.SEVERE_LEVEL),  # 4
+])
+
 
 # Load in VERSION from standalone file
 with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as version_file:
@@ -57,10 +72,13 @@ def main():
     parser.add_argument('filepaths', metavar='filepath', nargs='+', type=str, help='File to lint')
     parser.add_argument('--format', default='text', type=str, help='Format of the output (e.g. text, json)')
     parser.add_argument('--encoding', type=str, help='Encoding of the input file (e.g. utf-8)')
-    parser.add_argument('--level', default=2, type=int, choices=(1, 2, 3, 4),
+    parser.add_argument('--level', default='warning', type=str, choices=LEVEL_MAP,
                         help='Minimum docutils linting error level to report and consider as failing '
-                        '(integer, 1=info, 2=warning [default], 3=error, 4=severe)')
+                        '(lower case string, default is warning)')
     args = parser.parse_args()
+
+    # Want the level strings to appear in the --help text via choices, so convert now:
+    args.level = LEVEL_MAP[args.level]
 
     # Run the main argument
     _main(**args.__dict__)

--- a/restructuredtext_lint/cli.py
+++ b/restructuredtext_lint/cli.py
@@ -12,7 +12,7 @@ with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as version_fi
     VERSION = version_file.read().strip()
 
 
-def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=0):
+def _main(filepaths, format='text', stream=sys.stdout, encoding=None, level=2):
     error_dicts = []
     error_occurred = False
 

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -140,12 +140,12 @@ class TestRestructuredtextLintCLI(TestCase):
     def test_level_fail(self):
         """Confirm low --level threshold fails file with warnings only"""
         # This is the expected behaviour we are checking:
-        # $ rst-lint --level 2 second_short_heading.rst ; echo "Return code $?"
+        # $ rst-lint --level warning second_short_heading.rst ; echo "Return code $?"
         # WARNING second_short_heading.rst:6 Title underline too short.
         # WARNING second_short_heading.rst:6 Title underline too short.
         # Return code 2
         with self.assertRaises(subprocess.CalledProcessError) as e:
-            subprocess.check_output((sys.executable, rst_lint_path, '--level', '2', warning_rst),
+            subprocess.check_output((sys.executable, rst_lint_path, '--level', 'warning', warning_rst),
                                     universal_newlines=True)
         output = str(e.exception.output)
         self.assertEqual(2, output.count('\n'), output)
@@ -156,10 +156,10 @@ class TestRestructuredtextLintCLI(TestCase):
     def test_level_high(self):
         """Confirm high --level threshold accepts file with warnings only"""
         # This is the expected behaviour we are checking:
-        # $ rst-lint --level 3 second_short_heading.rst ; echo "Return code $?"
+        # $ rst-lint --level error second_short_heading.rst ; echo "Return code $?"
         # INFO File second_short_heading.rst is clean.
         # Return code 0
-        output = subprocess.check_output((sys.executable, rst_lint_path, '--level', '3', warning_rst),
+        output = subprocess.check_output((sys.executable, rst_lint_path, '--level', 'error', warning_rst),
                                          universal_newlines=True)
         self.assertEqual(1, output.count('\n'), output)
         self.assertEqual(1, output.count('is clean'), output)

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -158,3 +158,21 @@ class TestRestructuredtextLintCLI(TestCase):
                                     stderr=subprocess.DEVNULL)
             # 'rst-lint' should exit with error code 1 as bad argument:
             self.assertEqual(e.exception.returncode, 1)
+
+    def test_fail_level(self):
+        """Confirm --fail threshold works using file with warnings only"""
+        for level, failure in ((1, True), (2, True), (3, False), (4, False)):
+            # Would use subprocess.run but unavailable on Python 2
+            process = subprocess.Popen((sys.executable, rst_lint_path, '--fail', str(level), warning_rst),
+                                       universal_newlines=True,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.DEVNULL)
+            output, stderr = process.communicate()
+            self.assertEqual(2, output.count('\n'), output)
+            self.assertEqual(2, output.count('WARNING'), output)
+            if failure:
+                # The expected 2 warnings should be treated as failing
+                self.assertEqual(process.returncode, 2)
+            else:
+                # The expected 2 warnings should be treated as passing
+                self.assertEqual(process.returncode, 0)

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -136,15 +136,6 @@ class TestRestructuredtextLintCLI(TestCase):
         # There should be a least one invalid rst file:
         self.assertIn('WARNING', output)
 
-    def test_bad_level(self):
-        """Confirm return code 1 from bad --level argument"""
-        with self.assertRaises(subprocess.CalledProcessError) as e:
-            # Want to hide the error message from the test output
-            subprocess.check_output((sys.executable, rst_lint_path, '--level', '5', warning_rst),
-                                    stderr=subprocess.DEVNULL)
-            # 'rst-lint' should exit with error code 1 as bad argument:
-            self.assertEqual(e.exception.returncode, 1)
-
     def test_fail_low(self):
         """Confirm low --level threshold fails file with warnings only"""
         with self.assertRaises(subprocess.CalledProcessError) as e:

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -129,8 +129,8 @@ class TestRestructuredtextLintCLI(TestCase):
             # python ../cli.py test_files/valid.rst invalid.rst
             subprocess.check_output((sys.executable, rst_lint_path, valid_rst, invalid_rst))
         output = str(e.exception.output)
-        # 'rst-lint' should exit with error code 1:
-        self.assertEqual(e.exception.returncode, 1)
+        # 'rst-lint' should exit with error code 2 as linting failed:
+        self.assertEqual(e.exception.returncode, 2)
         # There should be a least one valid .rst file:
         self.assertIn('is clean', output)
         # There should be a least one invalid rst file:
@@ -145,7 +145,16 @@ class TestRestructuredtextLintCLI(TestCase):
                 subprocess.check_output((sys.executable, rst_lint_path, '--level', str(level), warning_rst),
                                         universal_newlines=True)
             output = str(e.exception.output)
-            # 'rst-lint' should exit with error code 1:
-            self.assertEqual(e.exception.returncode, 1)
+            # 'rst-lint' should exit with error code 2 as linting failed:
+            self.assertEqual(e.exception.returncode, 2)
             self.assertEqual(count, output.count('\n'), output)
             self.assertEqual(count, output.count('WARNING'), output)
+
+    def test_bad_level(self):
+        """Confirm return code 1 from bad --level argument"""
+        with self.assertRaises(subprocess.CalledProcessError) as e:
+            # Want to hide the error message from the test output
+            subprocess.check_output((sys.executable, rst_lint_path, '--level', '5', warning_rst),
+                                    stderr=subprocess.DEVNULL)
+            # 'rst-lint' should exit with error code 1 as bad argument:
+            self.assertEqual(e.exception.returncode, 1)

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -137,8 +137,13 @@ class TestRestructuredtextLintCLI(TestCase):
         # There should be a least one invalid rst file:
         self.assertIn('WARNING', output)
 
-    def test_fail_low(self):
+    def test_level_fail(self):
         """Confirm low --level threshold fails file with warnings only"""
+        # This is the expected behaviour we are checking:
+        # $ rst-lint --level 2 second_short_heading.rst ; echo "Return code $?"
+        # WARNING second_short_heading.rst:6 Title underline too short.
+        # WARNING second_short_heading.rst:6 Title underline too short.
+        # Return code 2
         with self.assertRaises(subprocess.CalledProcessError) as e:
             subprocess.check_output((sys.executable, rst_lint_path, '--level', '2', warning_rst),
                                     universal_newlines=True)
@@ -150,7 +155,10 @@ class TestRestructuredtextLintCLI(TestCase):
 
     def test_level_high(self):
         """Confirm high --level threshold accepts file with warnings only"""
-        # Should not see the 2 warnings, and expect return code zero
+        # This is the expected behaviour we are checking:
+        # $ rst-lint --level 3 second_short_heading.rst ; echo "Return code $?"
+        # INFO File second_short_heading.rst is clean.
+        # Return code 0
         output = subprocess.check_output((sys.executable, rst_lint_path, '--level', '3', warning_rst),
                                          universal_newlines=True)
         self.assertEqual(1, output.count('\n'), output)

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -72,7 +72,8 @@ class TestRestructuredtextLint(TestCase):
 
         This is a regression test for https://github.com/twolfson/restructuredtext-lint/issues/5
         """
-        errors = restructuredtext_lint.lint_file(warning_rst)
+        filepath = os.path.join(__dir__, 'test_files', 'second_short_heading.rst')
+        errors = restructuredtext_lint.lint_file(filepath)
         self.assertEqual(errors[0].line, 6)
         self.assertEqual(errors[0].source, warning_rst)
 

--- a/restructuredtext_lint/test/test.py
+++ b/restructuredtext_lint/test/test.py
@@ -75,7 +75,7 @@ class TestRestructuredtextLint(TestCase):
         filepath = os.path.join(__dir__, 'test_files', 'second_short_heading.rst')
         errors = restructuredtext_lint.lint_file(filepath)
         self.assertEqual(errors[0].line, 6)
-        self.assertEqual(errors[0].source, warning_rst)
+        self.assertEqual(errors[0].source, filepath)
 
     def test_invalid_target(self):
         """A document with an invalid target name raises an error


### PR DESCRIPTION
[Update: Scope of pull request narrowed following discussion below, now only filters reports and adjusts return code accordingly]

This would close #8, and also modifies the tool's command line return code from a simple ``0`` success vs ``1`` for problems, to report the maximum reported error level (thus ``0`` for no issues, ``1`` for info, ``2`` for warnings, ``3`` for error, and ``4`` for severe).

Note I have not currently done anything with level 5, which seems to be a fake-error level used in the ``docutils`` command line tool for no report filtering? 