### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ CLI Utility
 ^^^^^^^^^^^
 For your convenience, we present a CLI utility ``rst-lint`` (also available as ``restructuredtext-lint``).
 
-.. code:: bash
+.. code:: console
 
     $ rst-lint --help
     usage: rst-lint [-h] [--version] [--format {text,json}] [--encoding ENCODING]


### PR DESCRIPTION
```console
$ pygmentize -L | grep -A1 -E '^[*] (bash|console),'
* bash, sh, ksh, zsh, shell:
    Bash (filenames *.sh, *.ksh, *.bash, *.ebuild, *.eclass, *.exheres-0, *.exlib, *.zsh, .bashrc, bashrc, .bash_*, bash_*, zshrc, .zshrc, PKGBUILD)
--
* console, shell-session:
    Bash Session (filenames *.sh-session, *.shell-session)
```
You want the latter lexer.