### PR TITLE
Add https://pre-commit.com configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: rst-lint
+    name: rst-lint
+    description: reStructuredText linter
+    entry: rst-lint
+    language: python
+    types: [rst]


### PR DESCRIPTION
This allows one to use `restructuredtext-lint` using the [pre-commit] framework

One would use a configuration such as:

```yaml
-   repo: https://github.com/twolfson/restructuredtext-lint
    rev: ''  # fill in with sha / tag
    hooks:
    -   rst-lint
```

[pre-commit]: https://pre-commit.com

(related to #50)