### PR TITLE
pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: rst-lint
+  name: rst-lint
+  entry: rst-lint
+  stages: [commit, merge-commit, push, manual]
+  require_serial: true
+  language: python
+  minimum_pre_commit_version: '3.0.4'

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Other tools
 https://github.com/twolfson/restructuredtext-lint/wiki/Integration-in-other-tools
 
 pre-commit
-----------
+""""""""""
 
 To use in `pre-commit`_, add to your ``.pre-commit-config.yaml``
 

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,21 @@ Other tools
 
 https://github.com/twolfson/restructuredtext-lint/wiki/Integration-in-other-tools
 
+pre-commit
+----------
+
+To use in `pre-commit`_, add to your ``.pre-commit-config.yaml``
+
+.. code:: console
+
+  - repo: https://github.com/twolfson/restructuredtext-lint
+    rev: 1.4.0  # Specify the latest stable version
+    hooks:
+    - id: rst-lint
+      files: \.rst$
+
+.. _`pre-commit`: https://github.com/pre-commit/pre-commit
+
 PyPI issues
 ^^^^^^^^^^^
 While a document may lint cleanly locally, there can be issues when submitted it to `PyPI`_. Here are some common problems:


### PR DESCRIPTION
This PR adds support for use of the linter as a hook for pre-commit
