### PR TITLE
Added wheel compilation

### DIFF
--- a/.foundryrc
+++ b/.foundryrc
@@ -7,7 +7,7 @@
     "foundry-release-git",
     "foundry-release-pypi",
     {
-      "_comment": "Temporary workaround to build/upload wheel until https://github.com/twolfson/foundry-release-pypi/issues/3 resolved",
+      "_comment": "Workaround to build/upload wheel until https://github.com/twolfson/foundry-release-pypi/issues/3 resolved",
       "type": "customCommand",
       "updateFiles": "python -m build"
     },

--- a/.foundryrc
+++ b/.foundryrc
@@ -5,6 +5,15 @@
       "updateFiles": "echo \"$FOUNDRY_VERSION\" > restructuredtext_lint/VERSION"
     },
     "foundry-release-git",
-    "foundry-release-pypi"
+    "foundry-release-pypi",
+    {
+      "_comment": "Temporary workaround to build/upload wheel until https://github.com/twolfson/foundry-release-pypi/issues/3 resolved",
+      "type": "customCommand",
+      "updateFiles": "python -m build"
+    },
+    {
+      "type": "customCommand",
+      "updateFiles": "twine upload dist/*-${FOUNDRY_VERSION}-*.whl"
+    },
   ]
 }


### PR DESCRIPTION
https://github.com/twolfson/restructuredtext-lint/issues/70 informed us that including a wheel as a compilation step would be a kind action. After understanding why, we concur.

In this PR:

- Added workaround for building and uploading wheel, since it's likely https://github.com/twolfson/foundry-release-pypi/issues/3 can become a time sink
- Fixes #70 